### PR TITLE
FEATURE: Optionally allow HTML to be rendered within the backend message

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,12 @@ generates
 
 <img src="https://raw.githubusercontent.com/friendsofsilverstripe/backendmessages/master/images/screenshots/messages.png">
 
+#### Allow HTML in the backend messages
+
+Add the following to your config.yml
+```
+FriendsOfSilverStripe\Backendmessages\MessageBoxField:
+  allow_html: true
+```
+
 ## MISC: [Future ideas/development, issues](https://github.com/FriendsOfSilverStripe/backendmessages/issues), [Contributing](https://github.com/FriendsOfSilverStripe/backendmessages/blob/master/CONTRIBUTING.md), [License](https://github.com/FriendsOfSilverStripe/backendmessages/blob/master/license.md)

--- a/src/MessageBoxField.php
+++ b/src/MessageBoxField.php
@@ -18,6 +18,7 @@ use SilverStripe\Core\Config\Configurable;
 class MessageBoxField extends LiteralField
 {
     use Configurable;
+
     /**
      * @var string
      */
@@ -64,6 +65,5 @@ class MessageBoxField extends LiteralField
         } else {
             return '<p class="'.$this->classes.'"" name="'.$this->getName().'">'.$content.'</p>';
         }
-
     }
 }

--- a/src/MessageBoxField.php
+++ b/src/MessageBoxField.php
@@ -13,13 +13,22 @@
 namespace FriendsOfSilverStripe\Backendmessages;
 
 use SilverStripe\Forms\LiteralField;
+use SilverStripe\Core\Config\Configurable;
 
 class MessageBoxField extends LiteralField
 {
+    use Configurable;
     /**
      * @var string
      */
     protected $classes = 'message';
+
+    /**
+     * Allow generic messages to contain HTML.
+     * Defaults to false to maintain backwards compatibility
+     * @var bool
+     */
+    private static $allow_html = false;
 
     /**
      * @var string
@@ -50,6 +59,11 @@ class MessageBoxField extends LiteralField
             $content = $content->forTemplate();
         }
 
-        return '<p class="'.$this->classes.'"" name="'.$this->getName().'">'.$content.'</p>';
+        if($this->config()->allow_html === true) {
+            return '<div class="'.$this->classes.'"" name="'.$this->getName().'">'.$content.'</div>';
+        } else {
+            return '<p class="'.$this->classes.'"" name="'.$this->getName().'">'.$content.'</p>';
+        }
+
     }
 }

--- a/src/MessageBoxField.php
+++ b/src/MessageBoxField.php
@@ -27,7 +27,8 @@ class MessageBoxField extends LiteralField
     /**
      * Allow generic messages to contain HTML.
      * Defaults to false to maintain backwards compatibility
-     * @var bool
+     *
+     * @var boolean
      */
     private static $allow_html = false;
 


### PR DESCRIPTION
I was hoping to be able to render ordered lists and multiple lines within my CMS error and warning messages. The `<p>` tag will render the message on a single line, causing my lists to run outside of it. This setting changes it to a `<div>`, which fully contains any basic HTML included in it. 

It defaults to false, to avoid breaking backwards compatibility.