### PR TITLE
Allow PHP 8 & provide missing ViewableData use

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "silverstripe/framework": "^4.0"
     },
     "require-dev": {

--- a/src/MessageBoxField.php
+++ b/src/MessageBoxField.php
@@ -14,6 +14,7 @@ namespace FriendsOfSilverStripe\Backendmessages;
 
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\View\ViewableData;
 
 class MessageBoxField extends LiteralField
 {


### PR DESCRIPTION
There doesn't seem to be any code that would break under PHP 8.

Also, MessageBoxField referenced ViewableData (not fully qualified) without a use statement.